### PR TITLE
Add dash guard action

### DIFF
--- a/_apply_srec.bat
+++ b/_apply_srec.bat
@@ -1,1 +1,1 @@
-..\srecpatch.exe "ROMS\MADS.bin" "OUTPUT\MADS (Mengze).bin"<srecfile.txt
+TOOLS\srecpatch.exe "ROMS\MADS.bin" "OUTPUT\MADS (Mengze).bin"<srecfile.txt

--- a/_fixcrc.bat
+++ b/_fixcrc.bat
@@ -1,1 +1,1 @@
-..\fixheader.exe "OUTPUT\MADS (Mengze).bin"
+TOOLS\fixheader.exe "OUTPUT\MADS (Mengze).bin"

--- a/_make_srec.bat
+++ b/_make_srec.bat
@@ -1,1 +1,1 @@
-..\vasmm68k_mot_win32.exe patch.asm -chklabels -nocase -rangewarnings -Dvasm=1 -DBuildGEN=1 -Fbin -Fsrec -o srecfile.txt
+TOOLS\vasmm68k_mot_win32.exe patch.asm -chklabels -nocase -rangewarnings -Dvasm=1 -DBuildGEN=1 -Fbin -Fsrec -o srecfile.txt

--- a/patch.asm
+++ b/patch.asm
@@ -1,7 +1,19 @@
 
-ORIGIN_BUTTON_A_MAP                   set $00126CEF
-ORIGIN_BUTTON_B_MAP                   set $00126D07
-ORIGIN_BUTTON_C_MAP                   set $00126CFB
+ORIGIN_CODE_BUTTON_A_MAPPING          set $00126CEF
+ORIGIN_CODE_BUTTON_B_MAPPING          set $00126D07
+ORIGIN_CODE_BUTTON_C_MAPPING          set $00126CFB
+
+ORIGIN_BUTTON_CHANGE_VAR              set $00FFB803
+
+ORIGIN_ACTION_VAR                     set $00FFC66C
+
+ORIGIN_DASH_VAR                       set $00FFDD3C
+ORIGIN_HEAVY_PUNCH_VAR                set $00FFC6C0
+ORIGIN_LIGHT_PUNCH_VAR                set $00FFC6F8
+ORIGIN_OFFSET_VAR                     set $00FFB900
+
+ORIGIN_CODE_DASH_SET                  set $0011BA2A
+ORIGIN_CODE_DASH_RETURN               set $0011BA34
 
 ; Constants: -----------------------------------------------------------
 HEAVY_PUNCH:                          equ $01
@@ -9,13 +21,34 @@ LIGHT_PUNCH:                          equ $02
 GUARD:                                equ $03
 
 ; Overrides: -----------------------------------------------------------
-        org     ORIGIN_BUTTON_A_MAP
+        org     ORIGIN_CODE_BUTTON_A_MAPPING
         dc.b    HEAVY_PUNCH
 
-        org     ORIGIN_BUTTON_B_MAP
+        org     ORIGIN_CODE_BUTTON_B_MAPPING
         dc.b    LIGHT_PUNCH
 
-        org     ORIGIN_BUTTON_C_MAP
+        org     ORIGIN_CODE_BUTTON_C_MAPPING
         dc.b    GUARD
 
+        org     ORIGIN_CODE_DASH_SET
+        jmp     DASH_GUARD
+
 ; Change: ---------------------------------------------------------------
+        org     $001FD9A0
+DASH_GUARD
+        lea     (ORIGIN_DASH_VAR).w,A0
+        move.b  (A1,D0.l),(A0,D0.l)
+        lea     (ORIGIN_ACTION_VAR).w,A0
+        cmpi.l  #3,(A0,D0.l)
+        bne.w   JUMP_ORIGIN
+        move.b  (ORIGIN_BUTTON_CHANGE_VAR).w,D0
+        rol.b   #4,D0
+        andi.l  #7,D0
+        btst    #1,D0
+        beq.w   JUMP_ORIGIN
+        lea     (ORIGIN_LIGHT_PUNCH_VAR),A0
+        move.l  (ORIGIN_OFFSET_VAR).w,D0
+        asl.l   #2,D0
+        move.l  #1,(A0,D0.l)
+JUMP_ORIGIN
+        jmp     ORIGIN_CODE_DASH_RETURN


### PR DESCRIPTION
Originally the dash guard need to press two buttons in order. This change enable the dash guard with the Forward, Forward and C button which simplify the operation.